### PR TITLE
Harmonization of Kekulization failure/error definition

### DIFF
--- a/docs/errors.html
+++ b/docs/errors.html
@@ -130,7 +130,7 @@ may mask errors in your own code.</p>
 <span class="kn">import</span> <span class="nn">partialsmiles</span> <span class="k">as</span> <span class="nn">ps</span>
 
 <span class="k">try</span><span class="p">:</span>
-    <span class="n">ps</span><span class="o">.</span><span class="n">ParseSmiles</span><span class="p">(</span><span class="s2">&quot;C(C)(C)(C)(C)C&quot;</span><span class="p">,</span> <span class="n">partial</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
+    <span class="n">ps</span><span class="o">.</span><span class="n">ParseSmiles</span><span class="p">(</span><span class="s2">&quot;c1cc[nH]cc1&quot;</span><span class="p">,</span> <span class="n">partial</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
 <span class="k">except</span> <span class="n">ps</span><span class="o">.</span><span class="n">KekulizationError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
     <span class="nb">print</span><span class="p">(</span><span class="nb">repr</span><span class="p">(</span><span class="n">e</span><span class="p">),</span> <span class="n">file</span><span class="o">=</span><span class="n">sys</span><span class="o">.</span><span class="n">stderr</span><span class="p">)</span>
     <span class="c1"># KekulizationError(&#39;Aromatic system cannot be kekulized&#39;, &#39;c1cc[nH]cc1&#39;, 3)</span>

--- a/docs/errors.html
+++ b/docs/errors.html
@@ -57,7 +57,7 @@ may mask errors in your own code.</p>
     <span class="n">ps</span><span class="o">.</span><span class="n">ParseSmiles</span><span class="p">(</span><span class="s2">&quot;c1cccc1&quot;</span><span class="p">,</span> <span class="n">partial</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
 <span class="k">except</span> <span class="n">ps</span><span class="o">.</span><span class="n">Error</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
     <span class="nb">print</span><span class="p">(</span><span class="nb">repr</span><span class="p">(</span><span class="n">e</span><span class="p">),</span> <span class="n">file</span><span class="o">=</span><span class="n">sys</span><span class="o">.</span><span class="n">stderr</span><span class="p">)</span>
-    <span class="c1"># KekulizationFailure(&#39;Aromatic system cannot be kekulized&#39;, &#39;c1cccc1&#39;, 5)</span>
+    <span class="c1"># KekulizationError(&#39;Aromatic system cannot be kekulized&#39;, &#39;c1cccc1&#39;, 5)</span>
     <span class="nb">print</span><span class="p">(</span><span class="nb">str</span><span class="p">(</span><span class="n">e</span><span class="p">),</span> <span class="n">file</span><span class="o">=</span><span class="n">sys</span><span class="o">.</span><span class="n">stderr</span><span class="p">)</span>
     <span class="c1"># Aromatic system cannot be kekulized</span>
     <span class="c1">#  c1cccc1</span>
@@ -133,7 +133,7 @@ may mask errors in your own code.</p>
     <span class="n">ps</span><span class="o">.</span><span class="n">ParseSmiles</span><span class="p">(</span><span class="s2">&quot;C(C)(C)(C)(C)C&quot;</span><span class="p">,</span> <span class="n">partial</span><span class="o">=</span><span class="kc">False</span><span class="p">)</span>
 <span class="k">except</span> <span class="n">ps</span><span class="o">.</span><span class="n">KekulizationError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
     <span class="nb">print</span><span class="p">(</span><span class="nb">repr</span><span class="p">(</span><span class="n">e</span><span class="p">),</span> <span class="n">file</span><span class="o">=</span><span class="n">sys</span><span class="o">.</span><span class="n">stderr</span><span class="p">)</span>
-    <span class="c1"># KekulizationFailure(&#39;Aromatic system cannot be kekulized&#39;, &#39;c1cc[nH]cc1&#39;, 3)</span>
+    <span class="c1"># KekulizationError(&#39;Aromatic system cannot be kekulized&#39;, &#39;c1cc[nH]cc1&#39;, 3)</span>
     <span class="nb">print</span><span class="p">(</span><span class="nb">str</span><span class="p">(</span><span class="n">e</span><span class="p">),</span> <span class="n">file</span><span class="o">=</span><span class="n">sys</span><span class="o">.</span><span class="n">stderr</span><span class="p">)</span>
     <span class="c1"># Aromatic system cannot be kekulized</span>
     <span class="c1">#   c1cc[nH]cc1</span>

--- a/docs/source/errors.rst
+++ b/docs/source/errors.rst
@@ -30,7 +30,7 @@ may mask errors in your own code.
             ps.ParseSmiles("c1cccc1", partial=False)
         except ps.Error as e:
             print(repr(e), file=sys.stderr)
-            # KekulizationFailure('Aromatic system cannot be kekulized', 'c1cccc1', 5)
+            # KekulizationError('Aromatic system cannot be kekulized', 'c1cccc1', 5)
             print(str(e), file=sys.stderr)
             # Aromatic system cannot be kekulized
             #  c1cccc1
@@ -119,7 +119,7 @@ Kekulization errors can be caught as follows. Note that the indicated location o
             ps.ParseSmiles("C(C)(C)(C)(C)C", partial=False)
         except ps.KekulizationError as e:
             print(repr(e), file=sys.stderr)
-            # KekulizationFailure('Aromatic system cannot be kekulized', 'c1cc[nH]cc1', 3)
+            # KekulizationError('Aromatic system cannot be kekulized', 'c1cc[nH]cc1', 3)
             print(str(e), file=sys.stderr)
             # Aromatic system cannot be kekulized
             #   c1cc[nH]cc1

--- a/docs/source/errors.rst
+++ b/docs/source/errors.rst
@@ -116,7 +116,7 @@ Kekulization errors can be caught as follows. Note that the indicated location o
         import partialsmiles as ps
 
         try:
-            ps.ParseSmiles("C(C)(C)(C)(C)C", partial=False)
+            ps.ParseSmiles("c1cc[nH]cc1", partial=False)
         except ps.KekulizationError as e:
             print(repr(e), file=sys.stderr)
             # KekulizationError('Aromatic system cannot be kekulized', 'c1cc[nH]cc1', 3)

--- a/partialsmiles/__init__.py
+++ b/partialsmiles/__init__.py
@@ -29,4 +29,4 @@ __license__ = "MIT"
 __copyright__ = "Noel O'Boyle 2019"
 
 from .smiparser import ParseSmiles
-from .exceptions import Error, SMILESSyntaxError, KekulizationFailure, ValenceError
+from .exceptions import Error, SMILESSyntaxError, KekulizationError, ValenceError

--- a/partialsmiles/exceptions.py
+++ b/partialsmiles/exceptions.py
@@ -39,7 +39,7 @@ class SMILESSyntaxError(Error):
         idx -- index of the character in the SMILES when the error occurred
     """
 
-class KekulizationFailure(Error):
+class KekulizationError(Error):
     """Exception raised when an aromatic system cannot be kekulized
 
     Attributes:

--- a/partialsmiles/smiparser.py
+++ b/partialsmiles/smiparser.py
@@ -171,7 +171,7 @@ class SmilesParser:
             self.incompleteAtoms.update(x for x in self.prev if x is not None)
 
         self.handleError(ValenceError, self.validateValence())
-        self.handleError(KekulizationFailure, self.validateKekulization())
+        self.handleError(KekulizationError, self.validateKekulization())
         self.mol.openbonds = dict(self.openbonds)
         return self.mol
 

--- a/suite.py
+++ b/suite.py
@@ -315,7 +315,7 @@ class KekulizationTests(unittest.TestCase):
                 "s1cc2nc3c(n2n1)cccc3"
                 ]
         for smi in smis:
-            self.assertRaises(KekulizationFailure, ParseSmiles, smi, False)
+            self.assertRaises(KekulizationError, ParseSmiles, smi, False)
 
     
     def testCoverage(self):


### PR DESCRIPTION
This PR aims to harmonize how the previously named Kekulization failure -- now named Kekulization error -- is used by the script, and documented.  This resolves a portion of an earlier filed issue report aiming to replicate the showcased Kekulization error, too.